### PR TITLE
Update default platforms for Docker build workflow

### DIFF
--- a/.github/workflows/reusable-docker-build-native.yaml
+++ b/.github/workflows/reusable-docker-build-native.yaml
@@ -66,7 +66,7 @@ on:
         required: false
         type: string
         # common ones: linux/amd64,linux/arm64,linux/arm/v7
-        default: '["linux/amd64"]'
+        default: '["linux/amd64", "linux/arm64"]'
       tag-rules:
         # https://github.com/marketplace/actions/docker-metadata-action#tags-input
         description: Use docker-metadata action to create tags from a key-value pair list in CSV format


### PR DESCRIPTION
This PR supports the following features:

- set the default platforms to linux/amd64 and linux/arm64